### PR TITLE
A typo in `Startup.cs` file in the HtmlMinification project

### DIFF
--- a/html-minification/src/HtmlMinification/Startup.cs
+++ b/html-minification/src/HtmlMinification/Startup.cs
@@ -41,7 +41,7 @@ namespace HtmlMinification
                                      {
                                          options.MinificationSettings.RemoveRedundantAttributes = true;
                                          options.MinificationSettings.RemoveHttpProtocolFromAttributes = true;
-                                         options.MinificationSettings.RemoveHttpProtocolFromAttributes = true;
+                                         options.MinificationSettings.RemoveHttpsProtocolFromAttributes = true;
                                      })
                 .AddHttpCompression();
         }


### PR DESCRIPTION
The same typo there is in the [article](http://andrewlock.net/html-minification-using-webmarkupmin-in-asp-net-core/).